### PR TITLE
A TypedKey can now be marked as memoryResident or not

### DIFF
--- a/src/main/java/com/peel/appscope/AppScope.java
+++ b/src/main/java/com/peel/appscope/AppScope.java
@@ -83,7 +83,9 @@ public final class AppScope {
 
     public static <T> void bind(TypedKey<T> key, T value) {
         if (key.isPersistable()) {
-            persistentInstancesCache.put(key, value);
+            if (key.isMemoryResident()) {
+                persistentInstancesCache.put(key, value);
+            }
             if (key.hasProvider()) { // delegate to the provider
                 key.getProvider().update(value);
             } else {

--- a/src/test/java/com/peel/appscope/AndroidFixtures.java
+++ b/src/test/java/com/peel/appscope/AndroidFixtures.java
@@ -30,76 +30,100 @@ import android.content.SharedPreferences;
  * @author Inderjeet Singh
  */
 public class AndroidFixtures {
+    public interface PrefsListener {
+        public void onGet(String key);
+        public void onPut(String key, Object value);
+        public void onRemove(String key);
+    }
 
     public static Context createMockContext() {
+        return createMockContext(null);
+    }
+
+    public static Context createMockContext(PrefsListener listener) {
         Context context = Mockito.mock(Context.class);
-        SharedPreferences persistPrefs = createMockSharedPreferences(context);
-        SharedPreferences configPrefs = createMockSharedPreferences(context);
+        SharedPreferences persistPrefs = createMockSharedPreferences(context, listener);
+        SharedPreferences configPrefs = createMockSharedPreferences(context, listener);
         Mockito.when(context.getSharedPreferences("persistent_props", Context.MODE_PRIVATE)).thenReturn(persistPrefs);
         Mockito.when(context.getSharedPreferences("config_props", Context.MODE_PRIVATE)).thenReturn(configPrefs);
         return context;
     }
 
-    private static SharedPreferences createMockSharedPreferences(Context context) {
+    private static SharedPreferences createMockSharedPreferences(Context context, final PrefsListener listener) {
         final Map<String, Object> map = new HashMap<>();
         return new SharedPreferences() {
             @Override public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {}
             @Override public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {}
             @SuppressWarnings("unchecked") private <T> T get(String key, T defValue) {
+                if (listener != null) listener.onGet(key);
                 return map.containsKey(key) ? (T) map.get(key) : defValue;
             }
             @Override public Set<String> getStringSet(String key, Set<String> defValues) {
+                if (listener != null) listener.onGet(key);
                 return get(key, defValues);
             }
             @Override public String getString(String key, String defValue) {
+                if (listener != null) listener.onGet(key);
                 return get(key, defValue);
             }
             @Override public long getLong(String key, long defValue) {
+                if (listener != null) listener.onGet(key);
                 return get(key, defValue);
             }
             @Override public int getInt(String key, int defValue) {
+                if (listener != null) listener.onGet(key);
                 return get(key, defValue);
             }
             @Override public float getFloat(String key, float defValue) {
+                if (listener != null) listener.onGet(key);
                 return get(key, defValue);
             }
             @Override public boolean getBoolean(String key, boolean defValue) {
+                if (listener != null) listener.onGet(key);
                 return get(key, defValue);
             }
             @Override public Map<String, ?> getAll() {
                 return map;
             }
             @Override public boolean contains(String key) {
+                if (listener != null) listener.onGet(key);
                 return map.containsKey(key);
             }
             @Override public Editor edit() {
                 return new Editor() {
                     @Override public Editor remove(String key) {
                         map.remove(key);
+                        if (listener != null) listener.onRemove(key);
                         return this;
                     }
                     @Override public Editor putStringSet(String key, Set<String> values) {
                         map.put(key, values);
+                        if (listener != null) listener.onPut(key, values);
                         return this;
                     }
                     @Override public Editor putString(String key, String value) {
                         map.put(key, value);
+                        if (listener != null) listener.onPut(key, value);
                         return this;
                     }
                     @Override public Editor putLong(String key, long value) {
                         map.put(key, value);
+                        if (listener != null) listener.onPut(key, value);
                         return this;
                     }
                     @Override public Editor putInt(String key, int value) {
                         map.put(key, value);
+                        if (listener != null) listener.onPut(key, value);
                         return this;
                     }
                     @Override public Editor putFloat(String key, float value) {
                         map.put(key, value);
+                        if (listener != null) listener.onPut(key, value);
                         return this;
                     }
                     @Override public Editor putBoolean(String key, boolean value) {
                         map.put(key, value);
+                        if (listener != null) listener.onPut(key, value);
                         return this;
                     }
                     @Override public boolean commit() {

--- a/src/test/java/com/peel/appscope/MemoryResidentTest.java
+++ b/src/test/java/com/peel/appscope/MemoryResidentTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2018 Peel Technologies Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.peel.appscope;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.google.gson.Gson;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Unit tests for {@link AppScope}
+ *
+ * @author Inderjeet Singh
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Context.class, SharedPreferences.class})
+public class MemoryResidentTest {
+
+    private Context context;
+    private static final Gson gson = new Gson();
+
+    private String keyGet;
+
+    @Before
+    public void setUp() {
+        keyGet = null;
+        context = AndroidFixtures.createMockContext(new AndroidFixtures.PrefsListener() {
+            @Override public void onRemove(String key) {}
+            @Override public void onPut(String key, Object value) {}
+            @Override public void onGet(String key) {
+                keyGet = key;
+            }
+        });
+        AppScope.TestAccess.init(context, gson);
+    }
+
+    // no tests related to providers/memoryResident are needed as you can't construct
+    // a key with memoryResident = false, but provider = true. This is because a provider
+    // can't be bound for a key that is persistable.
+
+    @Test
+    public void testMemoryResidentWithPersistableKey() {
+        TypedKey<String> key = new TypedKey.Builder<>("testKey", String.class)
+                .persistable(true)
+                .memoryResident(true)
+                .build();
+        AppScope.bind(key, "19999999999");
+        AppScope.get(key);
+        assertNull(keyGet); // get didn't access pref
+    }
+
+    @Test
+    public void testMemoryResidentWithNonPersistableKey() {
+        TypedKey<String> key = new TypedKey.Builder<>("testKey", String.class)
+                .persistable(false)
+                .memoryResident(true)
+                .build();
+        AppScope.bind(key, "19999999999");
+        AppScope.get(key);
+        assertNull(keyGet); // get didn't access pref
+    }
+
+    @Test
+    public void testNonMemoryResidentWithPersistableKey() {
+        TypedKey<String> key = new TypedKey.Builder<>("testKey", String.class)
+                .persistable(true)
+                .memoryResident(false)
+                .build();
+        AppScope.bind(key, "19999999999");
+        AppScope.get(key);
+        assertEquals(key.getName(), keyGet); // get must access prefs
+    }
+
+    @Test
+    public void testNonMemoryResidentWithNonPersistableKeyFails() {
+        try {
+            new TypedKey.Builder<>("testKey", String.class)
+                .persistable(false)
+                .memoryResident(false)
+                .build();
+            fail();
+        } catch (IllegalArgumentException expected) { // a non persistable key must be kept in memory
+        }
+    }
+}


### PR DESCRIPTION
This fixes https://github.com/PeelTechnologies/appscope/issues/1